### PR TITLE
Use argparse to implement CLI (closes #15)

### DIFF
--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -8,8 +8,7 @@ from mathinterpreter.calculate import calc
 def main():
 
     repl = len(sys.argv) == 1
-    if not repl:
-        cli(repl=repl)
+    cli(repl=repl)
 
     while repl:
 
@@ -30,19 +29,26 @@ def main():
 
 def cli(repl):
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="A simple math interpreter with a command line interface and an interactive mode.",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
     parser.add_argument(
-        "operations",
-        help="Calculate operations, where operations is an string containing"
-        " a mathematical expression. "
-        "To include spaces on this expressions use single or double dashes"
-        ', \' or ", as in "1+1"',
-        type=str,
+        "expression",
+        nargs="*",
+        help="Evaluate expression, which must be in one of the following forms:\n"
+        "  1+1/2^4\n"
+        "  1 + 1 / 2^4\n"
+        "  1 + 1 / '(2^(4/2))'\n"
+        "Note that to properly include parenthesis on command line calls it is necessary to"
+        " use single or double dashes. Default: interactive mode.",
     )
     args = parser.parse_args()
+    text = "".join(args.expression)
 
-    value = calc(args.operations)
-    print(value)
+    if not repl:
+        value = calc(text)
+        print(value)
 
 
 if __name__ == "__main__":

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -1,10 +1,21 @@
+import argparse
 import readline
+import sys
 
 from mathinterpreter.calculate import calc
 
 
 def main():
-    while True:
+
+    nargs = len(sys.argv)
+    repl = nargs == 1
+
+    if nargs == 2:
+        text = sys.argv[1]
+        value = calc(text)
+        print(value)
+
+    while repl:
 
         try:
             text = input("calc > ")

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -7,13 +7,9 @@ from mathinterpreter.calculate import calc
 
 def main():
 
-    nargs = len(sys.argv)
-    repl = nargs == 1
-
-    if nargs == 2:
-        text = sys.argv[1]
-        value = calc(text)
-        print(value)
+    repl = len(sys.argv) == 1
+    if not repl:
+        cli(repl=repl)
 
     while repl:
 
@@ -30,6 +26,24 @@ def main():
 
         value = calc(text)
         print(value)
+
+
+def cli(repl):
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "operations",
+        help="Calculate operations, where operations is an string containing"
+        " a mathematical expression. "
+        "To include spaces on this expressions use single or double dashes"
+        ', \' or ", as in "1+1"',
+        type=str,
+    )
+    args = parser.parse_args()
+
+    value = calc(args.operations)
+    print(value)
+    exit()
 
 
 if __name__ == "__main__":

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -43,7 +43,6 @@ def cli(repl):
 
     value = calc(args.operations)
     print(value)
-    exit()
 
 
 if __name__ == "__main__":

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -41,7 +41,8 @@ def cli(repl):
         "  1 + 1 / 2^4\n"
         "  1 + 1 / '(2^(4/2))'\n"
         "Note that to properly include parenthesis on command line calls it is necessary to"
-        " use single or double dashes. Default: interactive mode.",
+        " use single or double quotes, ' or \", enclosing the expression.\n"
+        "Default: interactive mode.",
     )
     args = parser.parse_args()
     text = "".join(args.expression)


### PR DESCRIPTION
I am using ['argparse.RawTextHelpFormatter'](https://stackoverflow.com/a/70539181/15343867) with argparse so that it can accept line breaks within text labels.

If you have any thoughts about the help message. Please comment. It is currently in this way:

```bash
❯ mathinterpreter -h
usage: mathinterpreter [-h] [expression ...]

A simple math interpreter with a command line interface and an interactive mode.

positional arguments:
  expression  Evaluate expression, which must be in one of the following forms:
                1+1/2^4
                1 + 1 / 2^4
                1 + 1 / '(2^(4/2))'
              Note that to properly include parenthesis on command line calls it is necessary to use single or double quotes, ' or ", enclosing the expression.
              Default: interactive mode.

options:
  -h, --help  show this help message and exit

```

