### PR TITLE
Fix cli with None, REPL with non-ascii input, ctrl-D (fixes #65)

### DIFF
--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -28,7 +28,7 @@ def main():
                 break
             print_value(expression)
         else:
-            print("Invalid syntax")
+            print("Invalid input. Non-ASCII character(s) were giving as input.")
 
 
 def print_value(expression):

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -28,7 +28,7 @@ def main():
                 break
             print_value(text)
         else:
-            print("Invalid input!")
+            print("Invalid syntax")
 
 
 def print_value(text):

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -14,8 +14,11 @@ def main():
 
         try:
             text = input("calc > ")
-        except KeyboardInterrupt:
-            print("\n", KeyboardInterrupt.__doc__)
+        except KeyboardInterrupt as e:
+            print("\n", e.__doc__)
+        except EOFError:
+            print("EOFError")
+        finally:
             exit()
 
         text = text.strip()
@@ -23,8 +26,9 @@ def main():
             text = text.lower()
             if text in ["q", "quit"]:
                 break
-
             print_value(text)
+        else:
+            print("Invalid input!")
 
 
 def print_value(text):

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -7,28 +7,22 @@ from mathinterpreter.calculate import calc
 
 def main():
 
-    repl = len(sys.argv) == 1
-    cli(repl=repl)
+    if len(sys.argv) != 1:
+        cli()
+    else:
+        while True:
 
-    while repl:
-
-        try:
-            expression = input("calc > ")
-        except KeyboardInterrupt as e:
-            print("\n", e.__doc__)
-            exit()
-        except EOFError:
-            print("\nEOFError")
-            exit()
-
-        expression = expression.strip()
-        if expression.isascii():
-            expression = expression.lower()
-            if expression in ["q", "quit"]:
+            try:
+                expression = input("calc > ")
+            except (KeyboardInterrupt, EOFError) as error:
+                print("\n", type(error).__name__)
                 break
-            print_value(expression)
-        else:
-            print("Invalid input. Non-ASCII character(s) were giving as input.")
+            else:
+                expression = expression.strip().lower()
+                if expression in ["q", "quit"]:
+                    break
+
+                print_value(expression)
 
 
 def print_value(expression):
@@ -37,7 +31,7 @@ def print_value(expression):
         print(value)
 
 
-def cli(repl):
+def cli():
 
     parser = argparse.ArgumentParser(
         description="A simple math interpreter with a command line interface and an interactive mode.",
@@ -55,11 +49,9 @@ def cli(repl):
         "Default: interactive mode.",
     )
 
-    if not repl:
-        args = parser.parse_args()
-        expression = "".join(args.expression)
-
-        print_value(expression)
+    args = parser.parse_args()
+    expression = "".join(args.expression)
+    print_value(expression)
 
 
 if __name__ == "__main__":

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -16,9 +16,9 @@ def main():
             text = input("calc > ")
         except KeyboardInterrupt as e:
             print("\n", e.__doc__)
+            exit()
         except EOFError:
             print("EOFError")
-        finally:
             exit()
 
         text = text.strip()

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -18,7 +18,7 @@ def main():
             print("\n", e.__doc__)
             exit()
         except EOFError:
-            print("EOFError")
+            print("\nEOFError")
             exit()
 
         expression = expression.strip()

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -13,7 +13,7 @@ def main():
     while repl:
 
         try:
-            text = input("calc > ")
+            expression = input("calc > ")
         except KeyboardInterrupt as e:
             print("\n", e.__doc__)
             exit()
@@ -21,18 +21,18 @@ def main():
             print("EOFError")
             exit()
 
-        text = text.strip()
-        if text.isascii():
-            text = text.lower()
-            if text in ["q", "quit"]:
+        expression = expression.strip()
+        if expression.isascii():
+            expression = expression.lower()
+            if expression in ["q", "quit"]:
                 break
-            print_value(text)
+            print_value(expression)
         else:
             print("Invalid syntax")
 
 
-def print_value(text):
-    value = calc(text)
+def print_value(expression):
+    value = calc(expression)
     if value:
         print(value)
 
@@ -57,9 +57,9 @@ def cli(repl):
 
     if not repl:
         args = parser.parse_args()
-        text = "".join(args.expression)
+        expression = "".join(args.expression)
 
-        print_value(text)
+        print_value(expression)
 
 
 if __name__ == "__main__":

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -24,10 +24,13 @@ def main():
             if text in ["q", "quit"]:
                 break
 
-        if text:
-            value = calc(text)
-            if value:
-                print(value)
+            print_value(text)
+
+
+def print_value(text):
+    value = calc(text)
+    if value:
+        print(value)
 
 
 def cli(repl):
@@ -47,12 +50,12 @@ def cli(repl):
         " use single or double quotes, ' or \", enclosing the expression.\n"
         "Default: interactive mode.",
     )
-    args = parser.parse_args()
-    text = "".join(args.expression)
 
     if not repl:
-        value = calc(text)
-        print(value)
+        args = parser.parse_args()
+        text = "".join(args.expression)
+
+        print_value(text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now the REPL behaves as expected... 

```bash
❯ mathinterpreter
calc > 🐍
Invalid input. Non-ASCII character(s) were giving as input.
calc > c
Illegal character 'c'
calc >              # <--- Ctrl-C
 Program interrupted by user.
```

```bash
❯ mathinterpreter
calc >              # <--- Ctrl-D
EOFError
```

