### PR TITLE
Automatic detect project version based on  git tag

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,11 +12,15 @@ base: core22
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 
+adopt-info: mathinterpreter
 parts:
   mathinterpreter:
     plugin: python
     source-type: git
     source: https://github.com/ScientificThought/py-math-interpreter
+    override-pull: |
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=10)
 
 apps:
   mathinterpreter:


### PR DESCRIPTION
I used `craftctl` to automatically detect the version based on git tags. Current code was based on canonical's example:

https://snapcraft.io/docs/using-craftctl

but I am not sure whether it will be messed up when we add new tags (so far, there is only one tag on the project).